### PR TITLE
[FEAT]  Update Xcode 26 support

### DIFF
--- a/icc.xcodeproj/project.pbxproj
+++ b/icc.xcodeproj/project.pbxproj
@@ -2595,6 +2595,7 @@
 			baseConfigurationReference = A50A54BE1BE2FEEC00B669FB /* CardIO_Framework_Debug.xcconfig */;
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD)";
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "";
 				IPHONEOS_DEPLOYMENT_TARGET = 15.6;
 			};
 			name = Debug;
@@ -2604,6 +2605,7 @@
 			baseConfigurationReference = A50A54BF1BE2FEEC00B669FB /* CardIO_Framework_Release.xcconfig */;
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD)";
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "";
 				IPHONEOS_DEPLOYMENT_TARGET = 15.6;
 			};
 			name = Release;
@@ -2613,6 +2615,7 @@
 			baseConfigurationReference = A50A54BD1BE2FEEC00B669FB /* CardIO_Framework_Adhoc.xcconfig */;
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD)";
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "";
 				IPHONEOS_DEPLOYMENT_TARGET = 15.6;
 			};
 			name = AdHoc;

--- a/icc.xcodeproj/project.pbxproj
+++ b/icc.xcodeproj/project.pbxproj
@@ -2510,6 +2510,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = A50A54BA1BE2F7A800B669FB /* UnitTest_Debug.xcconfig */;
 			buildSettings = {
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "";
 				IPHONEOS_DEPLOYMENT_TARGET = 15.6;
 			};
 			name = Debug;
@@ -2518,6 +2519,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = A50A54BB1BE2F7A800B669FB /* UnitTest_Release.xcconfig */;
 			buildSettings = {
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "";
 				IPHONEOS_DEPLOYMENT_TARGET = 15.6;
 			};
 			name = Release;
@@ -2526,6 +2528,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = A50A54B91BE2F7A800B669FB /* UnitTest_AdHoc.xcconfig */;
 			buildSettings = {
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "";
 				IPHONEOS_DEPLOYMENT_TARGET = 15.6;
 			};
 			name = AdHoc;
@@ -2544,6 +2547,7 @@
 			baseConfigurationReference = A50A54AF1BE2F7A800B669FB /* CardIO_Static_Library_Debug.xcconfig */;
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD)";
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "";
 				IPHONEOS_DEPLOYMENT_TARGET = 15.6;
 			};
 			name = Debug;
@@ -2553,6 +2557,7 @@
 			baseConfigurationReference = A50A54B01BE2F7A800B669FB /* CardIO_Static_Library_Release.xcconfig */;
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD)";
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "";
 				IPHONEOS_DEPLOYMENT_TARGET = 15.6;
 			};
 			name = Release;
@@ -2562,6 +2567,7 @@
 			baseConfigurationReference = A50A54AE1BE2F7A800B669FB /* CardIO_Static_Library_AdHoc.xcconfig */;
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD)";
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "";
 				IPHONEOS_DEPLOYMENT_TARGET = 15.6;
 			};
 			name = AdHoc;
@@ -2570,6 +2576,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = A553B71B1BE32664006DF551 /* icc_Static_Library_Debug.xcconfig */;
 			buildSettings = {
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "";
 				IPHONEOS_DEPLOYMENT_TARGET = 15.6;
 			};
 			name = Debug;
@@ -2578,6 +2585,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = A553B71C1BE32664006DF551 /* icc_Static_Library_Release.xcconfig */;
 			buildSettings = {
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "";
 				IPHONEOS_DEPLOYMENT_TARGET = 15.6;
 			};
 			name = Release;
@@ -2586,6 +2594,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = A553B71C1BE32664006DF551 /* icc_Static_Library_Release.xcconfig */;
 			buildSettings = {
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "";
 				IPHONEOS_DEPLOYMENT_TARGET = 15.6;
 			};
 			name = AdHoc;
@@ -2624,6 +2633,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = A50A54B41BE2F7A800B669FB /* icc_Debug.xcconfig */;
 			buildSettings = {
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "";
 				IPHONEOS_DEPLOYMENT_TARGET = 15.6;
 			};
 			name = Debug;
@@ -2632,6 +2642,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = A50A54B51BE2F7A800B669FB /* icc_Release.xcconfig */;
 			buildSettings = {
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "";
 				IPHONEOS_DEPLOYMENT_TARGET = 15.6;
 			};
 			name = Release;
@@ -2640,6 +2651,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = A50A54B31BE2F7A800B669FB /* icc_AdHoc.xcconfig */;
 			buildSettings = {
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "";
 				IPHONEOS_DEPLOYMENT_TARGET = 15.6;
 			};
 			name = AdHoc;


### PR DESCRIPTION
Xcode 26 support update
CARDIO won't allow iOS 26 simulator, which fails the compilations if using xcode 26.